### PR TITLE
Support docker MongoDB linking env var

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -5,14 +5,16 @@ import datetime
 
 class Cache(object):
 
-    def __init__(self, mongoUri):
+    def __init__(self, dbUri, dbName=''):
         try:
-            client = pymongo.MongoClient(mongoUri)
-            dbName = pymongo.uri_parser.parse_uri(mongoUri)['database']
+            client = pymongo.MongoClient(dbUri)
+            if dbName == '':
+                dbName = pymongo.uri_parser.parse_uri(dbUri)['database']
             db = client[dbName]
             self.games = db.games
-        except:
-            print("WARNING: Cache is using null storage")
+        except Exception, err:
+            print "WARNING: Cache is using null storage"
+            print "  Exception: %s" % err
             self.games = nullmongo.NullCollection()
 
 

--- a/statistics.py
+++ b/statistics.py
@@ -5,16 +5,18 @@ from time import time
 
 class Statistics(object):
 
-    def __init__(self, mongoUri):
+    def __init__(self, dbUri, dbName=''):
         try:
-            client = pymongo.MongoClient(mongoUri)
-            dbName = pymongo.uri_parser.parse_uri(mongoUri)['database']
+            client = pymongo.MongoClient(dbUri)
+            if dbName == '':
+                dbName = pymongo.uri_parser.parse_uri(dbUri)['database']
             db = client[dbName]
             self.stats_profiles = db.stats_profiles
             self.stats_games_for_profiles = db.stats_games_for_profiles
             self.stats_games = db.stats_games
-        except:
-            print("WARNING: Statistics is using null storage")
+        except Exception, err:
+            print "WARNING: Statistics is using null storage"
+            print "  Exception: %s" % err
             self.stats_profiles = nullmongo.NullCollection()
             self.stats_games_for_profiles = nullmongo.NullCollection()
             self.stats_games = nullmongo.NullCollection()


### PR DESCRIPTION
In order to run Dissector inside Docker container, it might be desirable to use MongoDB instance also running inside container. Specially so since for us, MongoDB is just a cache that can be purged at any time.

This change checks the presence of MONGO_PORT (I don't understand the point of this name!) -env var, which is set if mongo is linked with docker --link=mongocontainername:mongo ..., and uses it if MONGO_URI is not defined.

MongoDB connection details are now search in order as:

Connection:
1) MONGO_URI env var
2) MONGO_URI config key
3) MONGO_PORT env var
4) Do not try to connect

Database name search in order:
1) MONGO_DB env var
2) MONGO_DB config key
3) If found from MONGO_URI (mongodb://host:port/database)
4) "steam-dissector" default
